### PR TITLE
Disable sanitize on default

### DIFF
--- a/module/hm.nix
+++ b/module/hm.nix
@@ -158,7 +158,7 @@ in {
 
       sanitizeOnShutdown = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         example = true;
         description = ''
           Clear cookies, history and other data on shutdown.


### PR DESCRIPTION
There is no need to clear cookies on default, waste of time with cookie isolation and temporary containers