### PR TITLE
feat: add ability to customize `userContent` styles

### DIFF
--- a/modules/hm/default.nix
+++ b/modules/hm/default.nix
@@ -85,7 +85,7 @@ in {
       "${defaultProfile}/chrome/userChrome.css".text = with cfg; import ./firefox/userChrome.nix {inherit theme lib cfg;};
 
       # userContent
-      "${defaultProfile}/chrome/userContent.css".text = import ./firefox/userContent.nix;
+      "${defaultProfile}/chrome/userContent.css".text = import ./firefox/userContent.nix {inherit cfg;};
 
       # user.js
       "${defaultProfile}/user.js".text = mkUserJs (import ./firefox/preferences {inherit cfg lib;}) cfg.settings;

--- a/modules/hm/firefox/userContent.nix
+++ b/modules/hm/firefox/userContent.nix
@@ -1,4 +1,4 @@
-''
+{ cfg }: ''
   /*
   ┌─┐┬┌┬┐┌─┐┬  ┌─┐
   └─┐││││├─┘│  ├┤
@@ -20,4 +20,6 @@
       scrollbar-width: none !important;
     }
   }
+
+  ${cfg.theme.extraContentCss}
 ''

--- a/modules/hm/options/theme.nix
+++ b/modules/hm/options/theme.nix
@@ -65,5 +65,16 @@ in {
       default = "";
       description = "Extra css for userChrome.css";
     };
+
+    extraContentCss = mkOption {
+      type = types.str;
+      example = ''
+        body {
+          background-color: red;
+        }
+      '';
+      default = "";
+      description = "Extra css for userContent.css";
+    };
   };
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`userChrome` can be customized, but `userContent` can't.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `theme.extraCssContent` option

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
