### PR TITLE
feat: override ui fonts

### DIFF
--- a/modules/hm/default.nix
+++ b/modules/hm/default.nix
@@ -85,7 +85,7 @@ in {
       "${defaultProfile}/chrome/userChrome.css".text = with cfg; import ./firefox/userChrome.nix {inherit theme lib cfg;};
 
       # userContent
-      "${defaultProfile}/chrome/userContent.css".text = import ./firefox/userContent.nix;
+      "${defaultProfile}/chrome/userContent.css".text = import ./firefox/userContent.nix {inherit cfg;};
 
       # user.js
       "${defaultProfile}/user.js".text = mkUserJs (import ./firefox/preferences {inherit cfg lib;}) cfg.settings;

--- a/modules/hm/firefox/userChrome.nix
+++ b/modules/hm/firefox/userChrome.nix
@@ -4,7 +4,7 @@
   lib,
 }: let
   inherit (lib) optionalString;
-  inherit (theme) background-darker background foreground font;
+  inherit (theme) background-darker background foreground font extraCss;
 in ''
   ${
     optionalString cfg.theme.simplefox.enable ''
@@ -238,6 +238,6 @@ in ''
       }
     ''
   }
-    ${cfg.theme.extraCss}
+    ${extraCss}
 
 ''

--- a/modules/hm/firefox/userChrome.nix
+++ b/modules/hm/firefox/userChrome.nix
@@ -233,7 +233,9 @@ in ''
         display: none !important;
       }
 
-
+      * {
+        font-family: "${font}" !important;
+      }
     ''
   }
     ${cfg.theme.extraCss}

--- a/modules/hm/firefox/userContent.nix
+++ b/modules/hm/firefox/userContent.nix
@@ -1,4 +1,4 @@
-''
+{ cfg }: ''
   /*
   ┌─┐┬┌┬┐┌─┐┬  ┌─┐
   └─┐││││├─┘│  ├┤
@@ -19,5 +19,9 @@
     :root {
       scrollbar-width: none !important;
     }
+  }
+
+  * {
+    font-family: "${cfg.theme.font}" !important;
   }
 ''

--- a/pkgs/simplefox/userChrome.nix
+++ b/pkgs/simplefox/userChrome.nix
@@ -31,7 +31,7 @@ in
       sed -i 's/19171a/${backgroundDarker}/g' userChrome.css
       sed -i 's/201e21/${background}/g' userChrome.css
       sed -i 's/Lato/${font}/g' userChrome.css
-      # TODO: fonts
+      echo '* { font-family: "${font}" !important; }' >> userChrome.css
     '';
 
     installPhase = ''


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

This will override all fonts to user font.

- `userChrome` will change the ui font
- `userContent` will change fonts of the extensions (tested on `uBlock Origin`)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
