### PR TITLE
feat: paint firefox ui with user's colors

### DIFF
--- a/modules/hm/firefox/preferences/default.nix
+++ b/modules/hm/firefox/preferences/default.nix
@@ -433,4 +433,7 @@
   "browser.contentblocking.report.vpn-android.url" = "";
   "browser.contentblocking.report.vpn-ios.url" = "";
   "browser.privatebrowsing.promoEnabled" = false;
+
+  # Enable `@-moz-document` media query
+  "layout.css.moz-document.content.enabled" = true;
 }

--- a/modules/hm/firefox/userContent.nix
+++ b/modules/hm/firefox/userContent.nix
@@ -1,4 +1,6 @@
-{cfg}: ''
+{cfg}: let
+  inherit (cfg.theme) font background background-darker foreground extraUserContent;
+in ''
   /*
   ┌─┐┬┌┬┐┌─┐┬  ┌─┐
   └─┐││││├─┘│  ├┤
@@ -22,9 +24,32 @@
   }
 
 
-  * {
-    font-family: "${cfg.theme.font}" !important;
+  @-moz-document url-prefix("about:") {
+    * {
+      font-family: "${font}" !important;
+    }
   }
 
-  ${cfg.theme.extraUserContent}
+  :root {
+    --in-content-page-background: #${background-darker} !important;
+    --in-content-page-color: #${foreground} !important;
+
+    --in-content-box-background: #${background} !important;
+    --in-content-table-background: #${background} !important;
+
+    --newtab-background-color: #${background-darker} !important;
+    --newtab-background-color-secondary: #${background} !important;
+    --newtab-text-primary-color: #${foreground} !important;
+    --newtab-primary-element-text-color: #${background-darker} !important;
+  }
+
+  html {
+    background: #${background-darker};
+  }
+
+  .search-wrapper .logo-and-wordmark .wordmark {
+    fill: #${foreground} !important;
+  }
+
+  ${extraUserContent}
 ''

--- a/modules/hm/options/theme.nix
+++ b/modules/hm/options/theme.nix
@@ -58,8 +58,8 @@ in {
     extraUserChrome = mkOption {
       type = types.str;
       example = ''
-         body {
-           background-color: red;
+        body {
+          background-color: red;
         }
       '';
       default = "";


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

`about:*` pages reflect ui colors

## Does this introduce a breaking change?

- [ ] Yes _(maybe?)_
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
