### PR TITLE
Remove -Profile flag from wrapper

### DIFF
--- a/modules/hm/firefox/default.nix
+++ b/modules/hm/firefox/default.nix
@@ -113,9 +113,7 @@
         + ''
           rm -rf $out/share/applications/*
           install -D ${desktopItem}/share/applications/Schizofox.desktop $out/share/applications/Schizofox.desktop
-          makeWrapper $out/bin/firefox $out/bin/schizofox \
-            --add-flags '-Profile ${profilesPath}/schizo.default'
-
+          makeWrapper $out/bin/firefox $out/bin/schizofox
         '';
     });
 in


### PR DESCRIPTION
Profile flag doesnt work as intented, causing hard to reproduce issues

Since we override `profiles.ini` file, there is no need to pass -Profile flag
https://github.com/schizofox/schizofox/blob/b2f813fca1d76ef24678e88b8fda9c30fca99a3a/modules/hm/default.nix#L73-L83
This pr fixes #47. Compatibility with other existing profiles didn't work in the first place. Passing flags is not proper form of isolation nor compatibility layer. Maybe we should look into containers https://nixos.wiki/wiki/Tor_Browser_in_a_Container

Another way is to patch firefox to read it's configuration from `.schizofox` instead of `.mozilla` dir, but that would be overkill.  #63 

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
