### PR TITLE
preferences/security: module option for disabling sessionRestore

### DIFF
--- a/modules/hm/firefox/preferences/default.nix
+++ b/modules/hm/firefox/preferences/default.nix
@@ -51,7 +51,7 @@ in {
   "content.notify.interval" = 100000;
 
   # Disable session restore
-  "browser.sessionstore.resume_from_crash" = false;
+  "browser.sessionstore.resume_from_crash" = cfg.security.noSessionRestore;
 
   # disable caching
   "browser.cache.disk.enable" = false;

--- a/modules/hm/options/security.nix
+++ b/modules/hm/options/security.nix
@@ -25,6 +25,16 @@ in {
       '';
     };
 
+    noSessionRestore = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Disable session restore on startup. This will will get rid of the
+        "Restore tabs" button on startup if Firefox has exited unexpectedly.
+      '';
+    };
+
     wrapWithProxychains = mkOption {
       type = types.bool;
       default = false;


### PR DESCRIPTION
`"browser.sessionstore.resume_from_crash"` is something people might want to compromise on, browsers *do* crash and data *is* lost when that occurs. Doesn't hurt to provide the freedom to change it.