### PR TITLE
fix: remove deprecated .desktop category

### DIFF
--- a/modules/home-manager/firefox/default.nix
+++ b/modules/home-manager/firefox/default.nix
@@ -24,7 +24,7 @@
       else "schizofox %U";
     icon = "${logo}";
     terminal = false;
-    categories = ["Application" "Network" "WebBrowser"];
+    categories = ["Network" "WebBrowser"];
     mimeTypes = ["text/html" "text/xml"];
   };
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe): remove deprecated code

## What is the current behavior?

`Application` category is included in the generated desktop file.

Issue Number: N/A

## What is the new behavior?

It is not.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

No, since nothing should rely on the application category, since it has already been deprecated.

