### PR TITLE
feat: Add extraSandboxBinds

### DIFF
--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -183,7 +183,8 @@ in {
                     "/app/etc/firefox"
                   ]
                 ]
-                ++ just' cursorTheme "${cursorTheme}";
+                ++ just' cursorTheme "${cursorTheme}"
+                ++ config.programs.schizofox.security.extraSandboxBinds;
 
               env = {
                 XDG_DATA_DIRS = lib.makeSearchPath "share" ([

--- a/modules/home-manager/options/security.nix
+++ b/modules/home-manager/options/security.nix
@@ -1,6 +1,6 @@
 {lib, ...}: let
   inherit (lib.options) mkOption mkEnableOption;
-  inherit (lib.types) str bool;
+  inherit (lib.types) str bool listOf;
 in {
   options.programs.schizofox.security = {
     userAgent = mkOption {
@@ -56,6 +56,15 @@ in {
       default = true;
       example = true;
       description = "runtime sandboxing with NixPak";
+    };
+
+    extraSandboxBinds = mkOption {
+      type = listOf str;
+      default = [];
+      example = [
+        "/home/\${username}/.config/tridactyl"
+      ];
+      description = "Extra read-only paths to bind-mount into the sandbox.";
     };
   };
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Can't add extra paths into sandbox
Issue Number: N/A

## What is the new behavior?
You can add extra read-only binds like this:
```
programs.schizofox.security.extraSandboxBinds = [
  "/home/${username}/.config/tridactyl"
];
```

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
Still didn't achieve everything that I need to realistically daily drive with sandboxing, but a step towards that.
I have to figure out how to add CJK fonts, and support IME