### PR TITLE
wrapper: allow passing custom arguments to the wrapper; allow disabling speech synthesis

### DIFF
--- a/flake/modules/home-manager/options/general.nix
+++ b/flake/modules/home-manager/options/general.nix
@@ -47,6 +47,7 @@ in {
     };
 
     extraWrapperArgs = mkOption {
+      default = {};
       type = submodule {
         freeformType = attrsOf anything;
 
@@ -55,25 +56,12 @@ in {
         # options are the ones we **want** type-checked so that the
         # end-user does not hit obscure errors due to type mismatches.
         options = {
-          nixExtensions = mkOption {
-            type = listOf package;
+          nativeMessagingHosts = mkOption {
             default = [];
-            example = ''
-              [
-                (fetchFirefoxAddon {
-                  name = "ublock"; # Has to be unique!
-                  url = "https://addons.mozilla.org/firefox/downloads/file/3679754/ublock_origin-1.31.0-an+fx.xpi";
-                  hash = "sha256-2e73AbmYZlZXCP5ptYVcFjQYdjDp4iPoEPEOSCVF5sA=";
-                })
-              ]
-            '';
-
+            example = "[pkgs.tridactyl-native]";
+            type = listOf package;
             description = ''
-              Additional Firefox extensions to be passed to wrapFirefox.
-
-              ::: {.warning}
-              This option can *only* be used with an ESR build of Firefox.
-              :::
+              List of packages that provide native messaging hosts.
             '';
           };
         };
@@ -90,6 +78,8 @@ in {
         interfaces in the Schizofox module, but it must also be used with
         great care.
 
+        Please see the documentation for the `wrapFirefox` function in
+        the nixpkgs manual.
       '';
     };
   };

--- a/flake/modules/home-manager/options/general.nix
+++ b/flake/modules/home-manager/options/general.nix
@@ -5,7 +5,7 @@
 }: let
   inherit (lib.options) mkEnableOption mkPackageOption mkOption literalExpression;
   inherit (lib.types) submodule attrsOf listOf package anything;
-  jsonType = (pkgs.formats.json {}).tyepe;
+  jsonType = (pkgs.formats.json {}).type;
 in {
   options.programs.schizofox = {
     enable = mkEnableOption "Schizofox";

--- a/flake/modules/home-manager/options/misc.nix
+++ b/flake/modules/home-manager/options/misc.nix
@@ -19,7 +19,7 @@ in {
       type = listOf attrs;
       default = [];
       description = "List of bookmarks to add to your Schizofox configuration";
-      example = literalExpression ''
+      example = ''
         [
           {
             Title = "Example";
@@ -45,8 +45,10 @@ in {
       right-click context menu that is disabled by default.
 
       ::: {.note}
-      Fixes the issue where a second context menu appears
-      on top of the YouTube one.
+      Setting this to true fixes an issue where a second
+      context menu appears on top of the YouTube one, which
+      was introduced by a security policy that disallows
+      web-pages from hijacking the context menu.
       :::
     '';
 
@@ -63,5 +65,16 @@ in {
     };
 
     firefoxSync = mkEnableOption "Firefox Sync";
+
+    speechSynthesisSupport = mkEnableOption ''
+      speech synthesis support in Firefox.
+
+      ::: {.note}
+      This is enabled by default in wrapFirefox due to accessibility
+      reasons, however, those who need rely on this feature may disable
+      speech synthesis support to reduce the closure size by a significant
+      amount
+      :::
+    '';
   };
 }

--- a/flake/pkgs/darkreader.nix
+++ b/flake/pkgs/darkreader.nix
@@ -24,8 +24,9 @@ in
     patchPhase = ''
       runHook prePatch
 
-      substituteInPlace src/defaults.ts --replace "181a1b" ${background}
-      substituteInPlace src/defaults.ts --replace "e8e6e3" ${foreground}
+      substituteInPlace src/defaults.ts \
+        --replace-fail "181a1b" ${background} \
+        --replace-fail "e8e6e3" ${foreground}
 
       runHook postPatch
     '';


### PR DESCRIPTION
...and other documentation fixes.

- cleans up Darkreader derivation
- adds `programs.schizofox.extraWrapperArgs`
  - From my commit message: `programs.schizofox.extraWrapperArgs` will allow the user to pass     a freeform attribute set to the wrapper, as is, in order to merge additional arguments to the initial wrapper. This is especially useful when wrapFirefox has new options that *do not* have options in Schizofox's module system yet. Do note that this is extremely experimental and very implicit. Expect breakage, and use with great care.
- adds `programs.schizofox.misc.speechSynthesisSupport` (bool) for optionally disabling speech synthesis. You can shave around a full GB by disabling speech synthesis.