### PR TITLE
firefox/preferences: tighten up TLS config

### DIFF
--- a/flake/modules/home-manager/firefox/preferences/default.nix
+++ b/flake/modules/home-manager/firefox/preferences/default.nix
@@ -360,10 +360,10 @@ in {
   # General settings
   "security.tls.unrestricted_rc4_fallback" = false;
   "security.tls.insecure_fallback_hosts.use_static_list" = false;
-  "security.tls.version.min" = 1;
+  "security.tls.version.min" = 3;
   "security.cert_pinning.enforcement_level" = 2;
   "security.remote_settings.crlite_filters.enabled" = true;
-  "security.ssl.require_safe_negotiation" = false;
+  "security.ssl.require_safe_negotiation" = true;
   "security.ssl.treat_unsafe_negotiation_as_broken" = true;
   "security.ssl3.rsa_seed_sha" = true;
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Minimum TLS version is 1.0 and insecure TLS negotiation is permitted

## What is the new behavior?

Set minimum TLS version to 1.2 and enforce secure TLS negotiation

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Also unsure if delegation should stay enabled - LW disables it, arkenfox also used to disable it:
https://github.com/arkenfox/user.js/commit/e7d20867cb50c0f934bc3883ce60e16ec69a82ef

But the mozzers are claiming it's a privacy feature: https://groups.google.com/g/mozilla.dev.platform/c/BdFOMAuCGW8


<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
