### PR TITLE
modules/home-manager: assert when the package's version does not match an esr release

### DIFF
--- a/flake/modules/home-manager/default.nix
+++ b/flake/modules/home-manager/default.nix
@@ -73,7 +73,7 @@ in {
         assertion = hasInfix "esr" cfg.package.version;
         message = ''
           The package provided to 'programs.schizofox.package' is not an ESR release of Firefox: ${cfg.package.pname}
-          
+
           For policies to function as intended, you must an ESR release of Firefox. If you think this is a mistake, please open an issue.
         '';
       }

--- a/flake/modules/home-manager/default.nix
+++ b/flake/modules/home-manager/default.nix
@@ -72,8 +72,9 @@ in {
       {
         assertion = hasInfix "esr" cfg.package.version;
         message = ''
-          Package ${cfg.package.pname} is not an ESR release of firefox.
-          The package provided to schizofox must be an ESR release, due to policy management differences.
+          The package provided to 'programs.schizofox.package' is not an ESR release of Firefox: ${cfg.package.pname}
+          
+          For policies to function as intended, you must an ESR release of Firefox. If you think this is a mistake, please open an issue.
         '';
       }
     ];

--- a/flake/modules/home-manager/default.nix
+++ b/flake/modules/home-manager/default.nix
@@ -7,7 +7,7 @@ self: {
   inherit (builtins) toJSON isBool isInt isString;
   inherit (pkgs.stdenvNoCC.hostPlatform) isDarwin;
   inherit (lib.modules) mkIf;
-  inherit (lib.strings) concatStrings;
+  inherit (lib.strings) concatStrings hasInfix;
   inherit (lib.attrsets) mapAttrsToList;
   inherit (lib.lists) optionals;
 
@@ -68,6 +68,16 @@ in {
   meta.maintainers = with lib.maintainers; [sioodmy NotAShelf];
   imports = [./options];
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = hasInfix "esr" cfg.package.version;
+        message = ''
+          Package ${cfg.package.pname} is not an ESR release of firefox.
+          The package provided to schizofox must be an ESR release, due to policy management differences.
+        '';
+      }
+    ];
+
     home.file = {
       # profile config
       "${firefoxConfigPath}/profiles.ini".text = ''


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently schizofox does not check for an ESR release of firefox in the config.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- If  the user changes the package option for the schizofox module, it is now asserted that the version contains the `esr` string, which is there for any ESR release.

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
Technically, if any users used a non-ESR release of firefox prior to this PR, then their configuration would break, though i find that unlikely. The fix is simply to use an ESR release instead.