### PR TITLE
Add option to customize .mozilla folder location

### DIFF
--- a/flake/modules/home-manager/default.nix
+++ b/flake/modules/home-manager/default.nix
@@ -39,6 +39,8 @@ self: {
   mozillaConfigPath =
     if isDarwin
     then "Library/Application Support/Mozilla"
+    else if cfg.misc.customMozillaFolder.enable
+    then "${config.home.homeDirectory}${cfg.misc.customMozillaFolder.path}"
     else "${config.home.homeDirectory}/.mozilla";
 
   firefoxConfigPath =
@@ -174,7 +176,14 @@ in {
                 (envSuffix "XDG_RUNTIME_DIR" "/doc")
                 (envSuffix "XDG_RUNTIME_DIR" "/dconf")
 
-                (sloth.concat [sloth.homeDir "/.mozilla"])
+                (
+                  if cfg.misc.customMozillaFolder.enable
+                  then [
+                    (sloth.concat' sloth.homeDir cfg.misc.customMozillaFolder.path)
+                    (sloth.concat' sloth.homeDir "/.mozilla")
+                  ]
+                  else "${config.home.homeDirectory}/.mozilla"
+                )
               ];
 
               bind.ro = builtins.concatLists [

--- a/flake/modules/home-manager/options/misc.nix
+++ b/flake/modules/home-manager/options/misc.nix
@@ -1,6 +1,12 @@
-{lib, ...}: let
+{
+  lib,
+  config,
+  ...
+}: let
   inherit (lib.options) mkOption mkEnableOption literalExpression;
   inherit (lib.types) enum listOf attrs bool str nullOr;
+
+  cfg = config.programs.schizofox;
 in {
   options.programs.schizofox.misc = {
     startPageURL = mkOption {
@@ -79,5 +85,42 @@ in {
       // {default = true;};
 
     showHomeButton = mkEnableOption "displaying Home Button in the toolbar";
+
+    customMozillaFolder = {
+      enable = mkEnableOption ''
+        a custom .mozilla folder for storing browser data.
+
+        You may want this so it doesn't clash with other firefox installations.
+      '';
+      path = let
+        # the extra check code has been taken from github.com/nix-community/disko
+        # it was, as far as I can tell written by Lassulus <https://github.com/lassulus>
+        # the project is licensed under MIT License,
+        # which can be found at https://github.com/nix-community/disko/blob/master/LICENSE
+        # Copyright (c) 2018, 2019, 2022–2024 Nix community projects
+        check = x: let
+          # The filter is used to normalize paths, i.e. to remove duplicated and
+          # trailing slashes.  It also removes leading slashes, thus we have to
+          # check for "/" explicitly below.
+          xs = lib.filter (s: lib.stringLength s > 0) (lib.splitString "/" x);
+        in
+          lib.isString x && (x == "/" || lib.length xs > 0) && lib.substring 0 1 x == "/";
+      in
+        mkOption {
+          type = lib.types.addCheck lib.types.str check;
+          default = "/.schizofox/mozilla";
+          example = "/.local/share/schizofox/mozilla";
+          description = "A relative path, from the users home directory, to the folder that will contain schizofoxes data and configuration";
+        };
+    };
   };
+  config.assertions = [
+    {
+      assertion = !(!cfg.security.sandbox.enable && cfg.misc.customMozillaFolder.enable);
+      message = ''
+        To use a custom .mozilla folder sanboxing must be enabled.
+        Enable sandboxing using 'programs.schizofox.security.sandbox.enable'
+      '';
+    }
+  ];
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently its impossible to set a custom .mozilla path, so one can't use a normal instance of Firefox with Schizofox because of collisions.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Adds an option for setting a custom path for `.mozilla` so it doesn't clash with normal Firefox

<!-- Please describe the behavior or changes that are being added by this PR. -->

- add option (under `misc`) `customMozillaFolder` for setting custom path
- use `NixPak`s sandboxing ability to mount custom path as `.mozilla` in the sandbox
- add assertion when using `customMozillaFolder` with sandboxing disabled

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
N/A
<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
