### PR TITLE
Update to Firefox ESR v140

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733333617,
-        "narHash": "sha256-nMMQXREGvLOLvUa0ByhYFdaL0Jov0t1wzLbKjr05P2w=",
+        "lastModified": 1748000383,
+        "narHash": "sha256-EaAJhwfJGBncgIV/0NlJviid2DP93cTMc9h0q6P6xXk=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "56f8ea8d502c87cf62444bec4ee04512e8ea24ea",
+        "rev": "231726642197817d20310b9d39dd4afb9e899489",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734344598,
-        "narHash": "sha256-wNX3hsScqDdqKWOO87wETUEi7a/QlPVgpC/Lh5rFOuA=",
+        "lastModified": 1750973805,
+        "narHash": "sha256-BZXgag7I0rnL/HMHAsBz3tQrfKAibpY2vovexl2lS+Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "83ecd50915a09dca928971139d3a102377a8d242",
+        "rev": "080e8b48b0318b38143d5865de9334f46d51fce3",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733970147,
-        "narHash": "sha256-63SguTBGenmU4jx7j44PVXlZMsWsALjaNPpRg9xlljs=",
+        "lastModified": 1750904490,
+        "narHash": "sha256-Ny2Ht4Kjv6gmNOjzoOmbDAZSTBxtthNxC9ZOPALPWUc=",
         "owner": "nixpak",
         "repo": "nixpak",
-        "rev": "fbbb572e595decf5e749d7fbeb27e1ff09484ff8",
+        "rev": "12ce6bd35274f7a4f6c00291ff5f6f69331eff5f",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736429638,
-        "narHash": "sha256-dDWqQqSgMQXw5eFtcyoVijv7HbYJZOIo+jWQdJtsxn4=",
+        "lastModified": 1751009538,
+        "narHash": "sha256-H5v0MWj6OuuX0ct9INuwJj5kLDA0jKozmUcd5XfR9a4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f81eabd5dd7c9213516fa2d3fc1d108a751340d4",
+        "rev": "ce34f10e7180bdae28e8a3b0ab2f8c0ad4383506",
         "type": "github"
       },
       "original": {

--- a/flake/modules/common/firefox/default.nix
+++ b/flake/modules/common/firefox/default.nix
@@ -70,7 +70,6 @@
         # How Schizofox should handle cookies
         Cookies = {
           Behavior = "accept";
-          ExpireAtSessionEnd = false;
           Locked = false;
         };
 

--- a/flake/modules/common/firefox/preferences/default.nix
+++ b/flake/modules/common/firefox/preferences/default.nix
@@ -236,6 +236,7 @@ in {
 
   # Disable urlbar suggestions
   "browser.urlbar.addons.featureGate" = false;
+  "browser.urlbar.fakespot.featureGate" = false;
   "browser.urlbar.mdn.featureGate" = false;
   "browser.urlbar.pocket.featureGate" = false;
   "browser.urlbar.weather.featureGate" = false;
@@ -288,7 +289,7 @@ in {
   "browser.cache.disk.enable" = false;
 
   # Disable media cache from writing to disk in Private Browsing
-  "browser.privatebrowsing.forceMediaMemoryCache" = false;
+  "browser.privatebrowsing.forceMediaMemoryCache" = true;
   "media.memory_cache_max_size" = 65536; # 64MB
 
   # Disable storing extra session data
@@ -492,9 +493,6 @@ in {
   # Remove special permissions for certain mozilla domains
   "permissions.manager.defaultsUrl" = "";
 
-  # Remove webchannel whitelist
-  "webchannel.allowObject.urlWhitelist" = "";
-
   # Use Punycode in Internationalized Domain Names to eliminate possible spoofing
   # Note: Might be undesirable for non-latin alphabet users since legitimate IDN's
   # are also punycoded. Test here: https://www.xn--80ak6aa92e.com/
@@ -587,7 +585,6 @@ in {
   "privacy.antitracking.enableWebcompat" = false;
 
   ## SHUTDOWN & SANITIZING
-  # TODO: v2 migration in FF128+
 
   # Enable Firefox to clear items on shutdown
   # Note: In FF129+ clearing "siteSettings" on shutdown (2811), or manually via site data (2820) and
@@ -596,13 +593,12 @@ in {
 
   # Set/enforce what items to clear on shutdown
   # Note: If "history" is true, downloads will also be cleared
-  "privacy.clearOnShutdown.cache" = security.sanitizeOnShutdown.sanitize.cache;
-  # "privacy.clearOnShutdown_v2.cache" = security.sanitizeOnShutdown.sanitize.cache;
-  "privacy.clearOnShutdown.downloads" = security.sanitizeOnShutdown.sanitize.downloads;
-  "privacy.clearOnShutdown.formdata" = security.sanitizeOnShutdown.sanitize.formdata;
-  "privacy.clearOnShutdown.history" = security.sanitizeOnShutdown.sanitize.history;
-  # "privacy.clearOnShutdown_v2.historyFormDataAndDownloads" = true;
-  "privacy.clearOnShutdown.siteSettings" = security.sanitizeOnShutdown.sanitize.siteSettings;
+  "privacy.clearOnShutdown_v2.cache" = security.sanitizeOnShutdown.sanitize.cache;
+  "privacy.clearOnShutdown_v2.downloads" = security.sanitizeOnShutdown.sanitize.downloads;
+  "privacy.clearOnShutdown_v2.formdata" = security.sanitizeOnShutdown.sanitize.formdata;
+  "privacy.clearOnShutdown_v2.browsingHistoryAndDownloads" = security.sanitizeOnShutdown.sanitize.history;
+  "privacy.clearOnShutdown_v2.historyFormDataAndDownloads" = false;
+  "privacy.clearOnShutdown_v2.siteSettings" = security.sanitizeOnShutdown.sanitize.siteSettings;
 
   # Set Session Restore to clear on shutdown
   "privacy.clearOnShutdown.openWindows" = security.noSessionRestore; #  Not needed if Session Restore is not used
@@ -683,6 +679,7 @@ in {
 
   # Disable using system colors
   "browser.display.use_system_colors" = false;
+  "widget.non-native-theme.use-theme-accent" = false;
 
   # Enforce links targeting new windows to open in a new tab instead
   #  - 1=most recent window or tab
@@ -824,7 +821,6 @@ in {
 
   "media.autoplay.default" = 5;
 
-  "javascript.use_us_english_locale" = true;
   "intl.accept_languages" = "en-US, en";
 
   # Allow unsigned langpacks
@@ -869,17 +865,20 @@ in {
   "browser.discovery.sites" = "http://127.0.0.1/";
   "services.sync.prefs.sync.browser.startup.homepage" = false;
   "dom.ipc.plugins.flash.subprocess.crashreporter.enabled" = false;
+  "browser.safebrowsing.downloads.remote.url" = "";
   "browser.safebrowsing.enabled" = false;
   "browser.safebrowsing.malware.enabled" = false;
-  "browser.safebrowsing.provider.google.updateURL" = "";
-  "browser.safebrowsing.provider.google.gethashURL" = "";
-  "browser.safebrowsing.provider.google4.updateURL" = "";
+  "browser.safebrowsing.provider.google4.dataSharingURL" = "";
   "browser.safebrowsing.provider.google4.gethashURL" = "";
+  "browser.safebrowsing.provider.google4.updateURL" = "";
+  "browser.safebrowsing.provider.google.gethashURL" = "";
+  "browser.safebrowsing.provider.google.updateURL" = "";
   "browser.safebrowsing.provider.mozilla.gethashURL" = "";
   "browser.safebrowsing.provider.mozilla.updateURL" = "";
   "services.sync.privacyURL" = "http://127.0.0.1/";
   "social.enabled" = false;
   "social.remote-install.enabled" = false;
+  "datareporting.usage.uploadEnabled" = false;
   "datareporting.healthreport.about.reportUrl" = "http://127.0.0.1/";
   "datareporting.healthreport.service.enabled" = false;
   "datareporting.healthreport.documentServerURI" = "http://127.0.0.1/";
@@ -887,6 +886,7 @@ in {
   "social.toast-notifications.enabled" = false;
   "browser.slowStartup.notificationDisabled" = true;
   "network.http.sendRefererHeader" = 2;
+  "browser.ml.chat.enabled" = false;
 
   # Prevent sites from taking over copy/paste
   "dom.event.clipboardevents.enabled" = false;
@@ -1022,15 +1022,10 @@ in {
   "security.tls.version.min" = 3;
   "security.ssl3.rsa_seed_sha" = true;
 
-  # force permission request to show real origin
-  "permissions.delegation.enabled" = true;
-
   # Avoid logjam attack
   "security.ssl3.dhe_rsa_aes_128_sha" = false;
   "security.ssl3.dhe_rsa_aes_256_sha" = false;
   "security.ssl3.dhe_dss_aes_128_sha" = false;
-  "security.ssl3.dhe_rsa_des_ede3_sha" = false;
-  "security.ssl3.rsa_des_ede3_sha" = false;
 
   # Disable Pocket integration
   "browser.pocket.enabled" = false;
@@ -1053,16 +1048,15 @@ in {
   # New tab settings
   "browser.newtabpage.activity-stream.showTopSites" = false;
   "browser.newtabpage.activity-stream.feeds.section.topstories" = false;
-  "browser.newtabpage.activity-stream.feeds.snippets" = false;
   "browser.newtabpage.activity-stream.disableSnippets" = true;
   "browser.newtabpage.activity-stream.tippyTop.service.endpoint" = "";
+  "browser.newtabpage.activity-stream.showWeather" = false;
 
   # Enable xrender
   "gfx.xrender.enabled" = true;
 
   # Disable push notifications
   "dom.webnotifications.enabled" = false;
-  "dom.webnotifications.serviceworker.enabled" = false;
   "dom.push.enabled" = false;
 
   # Disable recommended extensions
@@ -1094,4 +1088,17 @@ in {
 
   # Show more ssl cert infos
   "security.identityblock.show_extended_validation" = true;
+
+  # Purge session icon in Private Browsing windows
+  "browser.privatebrowsing.resetPBM.enabled" = true;
+
+  # Disable url trimming
+  "browser.urlbar.trimURLs" = false;
+
+  # Whether to enable Firefox AI Runtime features
+  "browser.ml.enable" = cfg.misc.aiRuntime.enable;
+  "browser.ml.modelHubRootUrl" = cfg.misc.aiRuntime.url;
+
+  # Enable creation of Text Fragment URLs
+  "dom.text_fragments.create_text_fragment.enabled" = true;
 }

--- a/flake/modules/common/firefox/preferences/default.nix
+++ b/flake/modules/common/firefox/preferences/default.nix
@@ -603,6 +603,9 @@ in {
   # Set Session Restore to clear on shutdown
   "privacy.clearOnShutdown.openWindows" = security.noSessionRestore; #  Not needed if Session Restore is not used
 
+  # How many closed tabs should Firefox persist between launches
+  "browser.sessionstore.max_tabs_undo" = security.maxTabsUndo;
+
   ## SANITIZE ON SHUTDOWN: RESPECTS "ALLOW" SITE EXCEPTIONS FF103+ | v2 migration is FF128+ ***/
   # Set "Cookies" and "Site Data" to clear on shutdown (if 2810 is true) [SETUP-CHROME]
   # Exceptions: A "cookie" permission also controls "offlineApps" (see note below). For cross-domain logins,

--- a/flake/modules/common/options/general.nix
+++ b/flake/modules/common/options/general.nix
@@ -9,7 +9,7 @@
 in {
   options.programs.schizofox = {
     enable = mkEnableOption "Schizofox";
-    package = mkPackageOption pkgs "firefox-esr-128-unwrapped" {
+    package = mkPackageOption pkgs "firefox-esr-140-unwrapped" {
       example = "firefox-esr-unwrapped";
     };
 

--- a/flake/modules/common/options/misc.nix
+++ b/flake/modules/common/options/misc.nix
@@ -68,6 +68,29 @@ in {
       '';
     };
 
+    aiRuntime = {
+      enable = mkEnableOption ''
+        Firefox AI Runtime
+        This includes stuff like website summaries when hovering over a link
+
+        ::: {.note}
+        LLM inference is done completely on the client, so there is no data
+        or privacy risk.
+        Model itself gets downloaded from model-hub.mozilla.org
+        :::
+      '';
+      url = mkOption {
+        type = str;
+        default =
+          if cfg.misc.aiRuntime.enable
+          then "https://model-hub.mozilla.org/"
+          else "http://127.0.0.1/";
+        defaultText = "http://127.0.0.1/";
+        example = literalExpression "file://$${relative/path/to/startpage.html}";
+        description = "An URL or an absolute path to your Firefox startpage";
+      };
+    };
+
     firefoxSync = mkEnableOption "Firefox Sync";
     translate.enable =
       mkEnableOption ''

--- a/flake/modules/common/options/security.nix
+++ b/flake/modules/common/options/security.nix
@@ -5,6 +5,7 @@
 }: let
   inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.types) str bool listOf;
+  inherit (lib.types.ints) unsigned;
 
   cfg = config.programs.schizofox.security;
 in {
@@ -107,6 +108,20 @@ in {
       description = ''
         Disable session restore on startup. This will will get rid of the
         "Restore tabs" button on startup if Firefox has exited unexpectedly.
+      '';
+    };
+
+    maxTabsUndo = mkOption {
+      type = unsigned;
+      default =
+        if cfg.sanitizeOnShutdown.sanitize.history
+        then 0
+        else 25;
+      defaultText = 25;
+      description = ''
+        How many tabs should you be able to restore. This is problematic
+        because it persists closed tabs between browser launches even with
+        history sanitization.
       '';
     };
 

--- a/flake/modules/common/options/security.nix
+++ b/flake/modules/common/options/security.nix
@@ -30,7 +30,7 @@ in {
 
     userAgent = mkOption {
       type = str;
-      default = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0";
+      default = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0";
       description = "Spoofed user agent string to be sent";
       example = ''
         ::: {.tip}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe): Update to Firefox v140

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

 - `browser.newtabpage.activity-stream.feeds.snippets` - deprecated v117
 - `browser.newtabpage.activity-stream.showWeather` - added in v130
 - `browser.privatebrowsing.forceMediaMemoryCache` - seems wrong? comment is about disabling writing to disk while the pref forces writing to MEMORY - and we didn't force it
 - `browser.urlbar.fakespot.featureGate` - added in v130
 - `javascript.use_us_english_locale` - removed since v119
 - `permissions.delegation.enabled` - deprecated v118
 - `privacy.clearOnShutdown_v2.historyFormDataAndDownloads` - idk how it works. name suggests that it clears 3 things at once? so maybe lets keep it off and just use the more granular options?
 - `security.ssl3.dhe_rsa_des_ede3_sha` - deprecated years ago https://github.com/mozilla/gecko-dev/commit/3b688452907b4356d3907b74e5344f400105cf19
 - `security.ssl3.rsa_des_ede3_sha` - deprecated v93
 - `webchannel.allowObject.urlWhitelist` - removed since v132
 - `widget.non-native-theme.use-theme-accent` - added in v133
 - `ExpireAtSessionEnd` - doesn't exist anymore and causes an error in `about:policies`


 - changed package to `firefox-esr-140-unwrapped`
 - enabled few useful features from newer versions that I couldn't find in UI/weren't enabled by default
 - updated useragent

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

No idea if those prefs are 100% correct but I checked if we include anything that's deprecated/removed options in Arkenfox and replicated it here excluding stuff that's security in depth.
Also included new stuff from both Arkenfox and Securefox

I think there's some AI functionality in newer versions, didn't check it yet and didn't see it in Securefox or Arkenfox

Package doesn't exist yet, but v140 will be out tomorrow so it'll be available soon.

How do we handle good defaults? Should we leave them as it is in Schizofox to enforce that setting?